### PR TITLE
Skip comma when # of authors == 2.

### DIFF
--- a/msf-wrapup.rb
+++ b/msf-wrapup.rb
@@ -130,7 +130,11 @@ def sort_and_pluralize_author(author_list)
     author_list = author_list.first
   else
     author_list[-1] = "and #{author_list[-1]}"
-    author_list = author_list.join(", ")
+    if author_list.length == 2
+      author_list = author_list.join(" ")
+    else
+      author_list = author_list.join(", ")
+    end
   end
 
   return author_list


### PR DESCRIPTION
Very minor tweak to not add a comma when there are exactly two authors.

Current behavior:

```
* [AlienVault OSSIM/USM Remote Code Execution](https://www.rapid7.com/db/modules/exploit/linux/http/alienvault_exec) by Mehmet Ince, and Peter Lapp
```

New behavior:

```
* [AlienVault OSSIM/USM Remote Code Execution](https://www.rapid7.com/db/modules/exploit/linux/http/alienvault_exec) by Mehmet Ince and Peter Lapp
```