### PR TITLE
Don't tack on a 'CVE-' if there's one there.

### DIFF
--- a/msf-wrapup.rb
+++ b/msf-wrapup.rb
@@ -155,7 +155,9 @@ def select_best_reference(ref_list)
     when /cve.mitre.*name=(.*)/, /cvedetails\x2ecom[\x5c\x2f]cve[\x5c\x2f]([^\x5c\x2f]*)/
       val = $1
       next if ret.to_s =~ /^(MS|ZDI)/
-      ret = "CVE-#{val}"
+      ret = ""
+      ret << "CVE-" unless val =~ /^CVE-/
+      ret << "#{val}"
     when /osvdb.org[\x5c\x2f](\d+)/
       val = $1
       next if ret.to_s =~ /^(MS|ZDI|CVE)/


### PR DESCRIPTION
Minor change.  I had noticed that msf-wrapup.rb has been , for the last few wrapup blog posts, anyway, tacking on an unnecessary 'CVE-' to the module descriptions, like so:

```
# New Modules

*Exploit modules* *(5 new)*
  * [WePresent WiPG-1000 Command Injection](https://www.rapid7.com/db/modules/exploit/linux/http/wipg1000_cmd_injection) by Matthias Brun
  * [Mercurial Custom hg-ssh Wrapper Remote Code Exec](https://www.rapid7.com/db/modules/exploit/linux/ssh/mercurial_ssh_exec) by claudijd
  * [Ghostscript Type Confusion Arbitrary Command Execution](https://www.rapid7.com/db/modules/exploit/unix/fileformat/ghostscript_type_confusion) by hdm and Atlassian Security Team exploits CVE-CVE-2017-8291
  * [Microsoft Office Word Malicious Hta Execution](https://www.rapid7.com/db/modules/exploit/windows/fileformat/office_word_hta) by sinn3r, DidierStevens, Haifei Li, Nixawk, ryHanson, vysec, and wdormann exploits CVE-CVE-2017-0199
  * [Disk Sorter Enterprise GET Buffer Overflow](https://www.rapid7.com/db/modules/exploit/windows/http/disksorter_bof) by Daniel Teixeira
*Auxiliary and post modules* *(1 new)*
  * [Upload and Execute](https://www.rapid7.com/db/modules/post/multi/manage/upload_exec) by egyp7
```

This change just checks if a 'CVE-' is already present and, if so, doesn't tack it on.